### PR TITLE
Add tags support for custom attribution and analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,33 @@ RubyLLM::Monitoring::Engine.middleware.use(Rack::Auth::Basic) do |username, pass
 end
 ```
 
+## Tags
+
+You can attach custom tags to any RubyLLM call for tracking, attribution, or analytics purposes. This is useful for tracking usage by user, feature, or any other dimension.
+
+```ruby
+# For Chat (set on the instance)
+chat = RubyLLM.chat(model: "gpt-4")
+chat.tags = { user_id: current_user.id, feature: "chat_assistant" }
+chat.ask("Hello")
+
+# For class methods (pass as argument)
+RubyLLM::Embedding.embed("text", tags: { user_id: current_user.id, feature: "search" })
+```
+
+Tags are stored in the `tags` JSON column and can be queried:
+
+```ruby
+# Find events by user
+RubyLLM::Monitoring::Event.where("tags->>'user_id' = ?", user.id.to_s)
+
+# Sum cost by feature
+RubyLLM::Monitoring::Event.where("tags->>'feature' = ?", "chat_assistant").sum(:cost)
+
+# PostgreSQL: Group by tag value
+RubyLLM::Monitoring::Event.group("tags->>'feature'").sum(:cost)
+```
+
 ## Alerts
 
 RubyLLM::Monitoring can send alerts when certain conditions are met. Useful for monitoring cost, errors, etc.

--- a/db/migrate/20260116044832_add_tags_to_ruby_llm_monitoring_events.rb
+++ b/db/migrate/20260116044832_add_tags_to_ruby_llm_monitoring_events.rb
@@ -1,0 +1,5 @@
+class AddTagsToRubyLLMMonitoringEvents < ActiveRecord::Migration[8.1]
+  def change
+    add_column :ruby_llm_monitoring_events, :tags, :json
+  end
+end

--- a/lib/ruby_llm/monitoring/event_subscriber.rb
+++ b/lib/ruby_llm/monitoring/event_subscriber.rb
@@ -11,6 +11,7 @@ module RubyLLM
           idle_time: event.idle_time,
           name: event.name,
           payload: event.payload,
+          tags: event.payload[:tags],
           time: event.time,
           transaction_id: event.transaction_id
         )

--- a/test/fixtures/ruby_llm/monitoring/events.yml
+++ b/test/fixtures/ruby_llm/monitoring/events.yml
@@ -77,3 +77,17 @@ anthropic_error:
   end: <%= (Time.current + 1.second).to_f %>
   transaction_id: "txn-anthropic-error"
   created_at: <%= 30.minutes.ago %>
+
+anthropic_with_tags:
+  name: "complete_chat.ruby_llm"
+  payload: { "provider": "anthropic", "model": "claude-3-5-sonnet-20241022", "input_tokens": 500, "output_tokens": 200 }
+  tags: { "user_id": 123, "feature": "chat_assistant" }
+  duration: 800.0
+  allocations: 3000
+  cpu_time: 500.0
+  gc_time: 30.0
+  idle_time: 270.0
+  time: <%= Time.current.to_f %>
+  end: <%= (Time.current + 0.8.seconds).to_f %>
+  transaction_id: "txn-anthropic-tags"
+  created_at: <%= 15.minutes.ago %>

--- a/test/lib/ruby_llm/monitoring/event_subscriber_test.rb
+++ b/test/lib/ruby_llm/monitoring/event_subscriber_test.rb
@@ -48,5 +48,39 @@ module RubyLLM::Monitoring
       assert_equal "StandardError", event.exception_class
       assert_equal "Something went wrong", event.exception_message
     end
+
+    test "extracts tags from payload" do
+      notification_event = ActiveSupport::Notifications::Event.new(
+        "complete_chat.ruby_llm",
+        Time.current,
+        Time.current + 1.second,
+        "transaction-789",
+        { provider: "ollama", model: "gemma3", input_tokens: 100, output_tokens: 50, tags: { user_id: 123, feature: "chat_assistant" } }
+      )
+
+      assert_difference "Event.count", 1 do
+        EventSubscriber.new.call(notification_event)
+      end
+
+      event = Event.last
+      assert_equal({ "user_id" => 123, "feature" => "chat_assistant" }, event.tags)
+    end
+
+    test "handles nil tags" do
+      notification_event = ActiveSupport::Notifications::Event.new(
+        "complete_chat.ruby_llm",
+        Time.current,
+        Time.current + 1.second,
+        "transaction-000",
+        { provider: "ollama", model: "gemma3", input_tokens: 100, output_tokens: 50 }
+      )
+
+      assert_difference "Event.count", 1 do
+        EventSubscriber.new.call(notification_event)
+      end
+
+      event = Event.last
+      assert_nil event.tags
+    end
   end
 end


### PR DESCRIPTION
## Summary

This PR adds support for capturing and storing tags from instrumentation events. Tags enable querying events by user, feature, or any custom dimension.

### Depends on

This PR depends on sinaptia/ruby_llm-instrumentation#7 which adds tags support to the instrumentation gem.

### Changes

- New migration adding `tags` JSON column to `ruby_llm_monitoring_events`
- `EventSubscriber` now captures `tags` from the event payload
- README updated with usage examples and query patterns

### Usage

```ruby
# Set tags when making LLM calls
chat = RubyLLM.chat(model: "gpt-4")
chat.tags = { user_id: current_user.id, feature: "chat_assistant" }
chat.ask("Hello")

# Query by tags
RubyLLM::Monitoring::Event.where("tags->>'user_id' = ?", user.id.to_s)
RubyLLM::Monitoring::Event.where("tags->>'feature' = ?", "chat_assistant").sum(:cost)
```

### Use cases

- Track LLM usage per user for billing or quotas
- Identify which features consume the most tokens/cost
- Attribute usage to teams or projects
- Debug issues by correlating with request IDs

## Discussion

Similar to the instrumentation PR, this is primarily to start a discussion. Happy to iterate based on feedback.