### PR TITLE
Add test for metadata in payload

### DIFF
--- a/test/fixtures/ruby_llm/monitoring/events.yml
+++ b/test/fixtures/ruby_llm/monitoring/events.yml
@@ -77,3 +77,16 @@ anthropic_error:
   end: <%= (Time.current + 1.second).to_f %>
   transaction_id: "txn-anthropic-error"
   created_at: <%= 30.minutes.ago %>
+
+anthropic_with_metadata:
+  name: "complete_chat.ruby_llm"
+  payload: { "provider": "anthropic", "model": "claude-3-5-sonnet-20241022", "input_tokens": 500, "output_tokens": 200, "metadata": { "user_id": 123, "feature": "chat_assistant" } }
+  duration: 800.0
+  allocations: 3000
+  cpu_time: 500.0
+  gc_time: 30.0
+  idle_time: 270.0
+  time: <%= Time.current.to_f %>
+  end: <%= (Time.current + 0.8.seconds).to_f %>
+  transaction_id: "txn-anthropic-metadata"
+  created_at: <%= 15.minutes.ago %>


### PR DESCRIPTION
## Summary

Adds a test confirming metadata from ruby_llm-instrumentation is stored in the event payload. This supersedes #15.

### Depends on

sinaptia/ruby_llm-instrumentation#10

### Changes

- Test verifying metadata is stored in `payload["metadata"]`
- Fixture with metadata example

No code changes needed - the monitoring gem already stores the full payload.

Closes #15