### PR TITLE
Remove groupdate dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,6 @@ PATH
   remote: .
   specs:
     ruby_llm-monitoring (0.3.2)
-      groupdate
       importmap-rails
       rails (>= 7.2.0)
       ruby_llm
@@ -128,8 +127,6 @@ GEM
       faraday (~> 2.0)
     globalid (1.3.0)
       activesupport (>= 6.1)
-    groupdate (6.8.0)
-      activesupport (>= 7.2)
     hashdiff (1.2.1)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)

--- a/app/models/concerns/ruby_llm/monitoring/time_grouping.rb
+++ b/app/models/concerns/ruby_llm/monitoring/time_grouping.rb
@@ -1,0 +1,30 @@
+module RubyLLM
+  module Monitoring
+    module TimeGrouping
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def group_by_minute(column, range:, n: 1)
+          interval = n * 60
+          quoted = connection.quote_column_name(column)
+          bucket_expr = time_bucket_expression(quoted, interval)
+
+          where(column => range).group(Arel.sql(bucket_expr))
+        end
+
+        private
+
+        def time_bucket_expression(column, interval)
+          case connection.adapter_name
+          when "PostgreSQL", "PostGIS", "Redshift"
+            "FLOOR(EXTRACT(EPOCH FROM #{column}) / #{interval}) * #{interval}"
+          when "Mysql2", "Mysql2Spatial", "Mysql2Rgeo", "Trilogy"
+            "FLOOR(UNIX_TIMESTAMP(#{column}) / #{interval}) * #{interval}"
+          else
+            "(strftime('%s', #{column}) / #{interval}) * #{interval}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/concerns/ruby_llm/monitoring/time_grouping.rb
+++ b/app/models/concerns/ruby_llm/monitoring/time_grouping.rb
@@ -20,8 +20,10 @@ module RubyLLM
             "FLOOR(EXTRACT(EPOCH FROM #{column}) / #{interval}) * #{interval}"
           when "Mysql2", "Mysql2Spatial", "Mysql2Rgeo", "Trilogy"
             "FLOOR(UNIX_TIMESTAMP(#{column}) / #{interval}) * #{interval}"
-          else
+          when "SQLite"
             "(strftime('%s', #{column}) / #{interval}) * #{interval}"
+          else
+            raise "Unsupported adapter: #{connection.adapter_name}"
           end
         end
       end

--- a/app/models/ruby_llm/monitoring/event.rb
+++ b/app/models/ruby_llm/monitoring/event.rb
@@ -1,6 +1,7 @@
 module RubyLLM::Monitoring
   class Event < ApplicationRecord
     include Alertable
+    include TimeGrouping
 
     before_validation :set_cost
 

--- a/lib/ruby_llm/monitoring.rb
+++ b/lib/ruby_llm/monitoring.rb
@@ -1,4 +1,3 @@
-require "groupdate"
 require "ruby_llm"
 require "ruby_llm/instrumentation"
 require "ruby_llm/monitoring/channel_registry"

--- a/ruby_llm-monitoring.gemspec
+++ b/ruby_llm-monitoring.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |spec|
     Dir["{app,config,db,lib}/**/*", "CHANGELOG.md", "MIT-LICENSE", "Rakefile", "README.md"]
   end
 
-  spec.add_dependency "groupdate"
   spec.add_dependency "importmap-rails"
   spec.add_dependency "rails", ">= 7.2.0"
   spec.add_dependency "ruby_llm"

--- a/test/models/concerns/ruby_llm/monitoring/time_grouping_test.rb
+++ b/test/models/concerns/ruby_llm/monitoring/time_grouping_test.rb
@@ -1,0 +1,60 @@
+require "test_helper"
+
+module RubyLLM::Monitoring
+  class TimeGroupingTest < ActiveSupport::TestCase
+    test "group_by_minute scopes records within range" do
+      range = Time.zone.parse("2025-01-05 12:00:00")..Time.zone.parse("2025-01-05 13:00:00")
+      results = Event.group_by_minute(:created_at, range: range).count
+
+      assert results.values.all? { |v| v > 0 }
+    end
+
+    test "group_by_minute excludes records outside range" do
+      range = Time.zone.parse("2020-01-01")..Time.zone.parse("2020-01-01 01:00:00")
+      results = Event.group_by_minute(:created_at, range: range).count
+
+      assert_empty results
+    end
+
+    test "group_by_minute groups into time buckets with numeric keys" do
+      range = Time.zone.parse("2025-01-05 12:00:00")..Time.zone.parse("2025-01-05 13:00:00")
+      results = Event.group_by_minute(:created_at, range: range).count
+
+      results.each_key do |key|
+        assert_kind_of Numeric, key, "Expected numeric bucket key, got #{key.class}"
+        assert_equal 0, key.to_i % 60, "Expected bucket key to be aligned to 60-second intervals"
+      end
+    end
+
+    test "group_by_minute respects n parameter for multi-minute buckets" do
+      range = Time.zone.parse("2025-01-05 12:00:00")..Time.zone.parse("2025-01-05 13:00:00")
+      results = Event.group_by_minute(:created_at, range: range, n: 5).count
+
+      results.each_key do |key|
+        assert_equal 0, key.to_i % 300, "Expected bucket key to be aligned to 300-second intervals"
+      end
+    end
+
+    test "group_by_minute works with chained aggregations" do
+      range = Time.zone.parse("2025-01-05 12:00:00")..Time.zone.parse("2025-01-05 13:00:00")
+      results = Event.group_by_minute(:created_at, range: range).group(:provider, :model).count
+
+      assert_not_empty results
+      results.each_key do |(bucket, _provider, _model)|
+        assert_kind_of Numeric, bucket
+      end
+    end
+
+    test "raises error for unsupported adapter" do
+      original_method = Event.connection.method(:adapter_name)
+      Event.connection.define_singleton_method(:adapter_name) { "UnknownDB" }
+
+      error = assert_raises(RuntimeError) do
+        Event.group_by_minute(:created_at, range: 1.hour.ago..Time.current).count
+      end
+      assert_match(/Unsupported adapter: UnknownDB/, error.message)
+    ensure
+      Event.connection.define_singleton_method(:adapter_name, original_method)
+    end
+  end
+end


### PR DESCRIPTION
## Problem

The `groupdate` gem raises `Groupdate::Error` when `ActiveRecord.default_timezone` is set to `:local`:

```
Groupdate::Error: ActiveRecord.default_timezone must be :utc to use Groupdate
```

This prevents apps that use `:local` timezone from using `ruby_llm-monitoring`.

## Fix

Replace the `groupdate` gem with a built-in `TimeGrouping` concern that uses adapter-specific SQL for time bucketing. The concern provides `group_by_minute` with the same interface as groupdate, using epoch-based truncation:

- **PostgreSQL / PostGIS / Redshift**: `FLOOR(EXTRACT(EPOCH FROM ...) / interval) * interval`
- **MySQL2 / Mysql2Spatial / Mysql2Rgeo / Trilogy**: `FLOOR(UNIX_TIMESTAMP(...) / interval) * interval`
- **SQLite**: `(strftime('%s', ...) / interval) * interval`

Adapter names are matched consistently with [groupdate's own `register_adapter` mappings](https://github.com/ankane/groupdate/blob/v6.8.0/lib/groupdate.rb#L46-L48).